### PR TITLE
Add testing to validate document creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# VSCode config
+/.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
   - elasticsearch
   - redis-server
 python:
-- 3.6
-- 2.7
+- "3.6"
+- "2.7"
 
 stages:
 - lint

--- a/pacifica/elasticsearch/celery.py
+++ b/pacifica/elasticsearch/celery.py
@@ -28,7 +28,9 @@ class CeleryQueue(object):
 
     def put(self, job_dict):
         """Save job dictionary and run job."""
+        # pylint: disable=cyclic-import
         from .tasks import work_on_job
+        # pylint: enable=cyclic-import
         result = work_on_job.delay(job_dict)
         self.all_jobs.append((job_dict, result))
         if not job_dict['object'] in self.by_obj_type:

--- a/pacifica/elasticsearch/render/projects.py
+++ b/pacifica/elasticsearch/render/projects.py
@@ -3,6 +3,7 @@
 """Search transaction rendering methods."""
 from six import text_type
 from .base import SearchBase
+from .users import UsersRender
 
 
 class ProjectsRender(SearchBase):
@@ -12,6 +13,10 @@ class ProjectsRender(SearchBase):
         'obj_id', 'display_name', 'abstract', 'title',
         'keyword', 'release', 'closed_date', 'actual_end_date',
         'updated_date', 'created_date', 'actual_start_date'
+    ]
+
+    rel_objs = [
+        'users'
     ]
 
     @staticmethod
@@ -85,3 +90,16 @@ class ProjectsRender(SearchBase):
             'transactions_{}'.format(trans_id)
             for trans_id in cls._transsip_transsap_merge({'project': proj_obj['_id']}, '_id')
         ]
+
+    @classmethod
+    def users_obj_lists(cls, **proj_obj):
+        """Get the user objects and relationships."""
+        ret = {}
+        for proj_user_obj in cls.get_rel_by_args('project_user', project=proj_obj['_id']):
+            rel_obj = cls.get_rel_by_args('relationships', uuid=proj_user_obj['relationship'])[0]
+            rel_list = ret.get(rel_obj['name'], [])
+            rel_list.append(
+                UsersRender.render(cls.get_rel_by_args('users', _id=proj_user_obj['user'])[0])
+            )
+            ret[rel_obj['name']] = rel_list
+        return ret

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 coverage
+jsonschema
 pacifica-policy>=0.7.0,<1
 pep257
 pre-commit

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description_content_type='text/markdown',
     author='David Brown',
     author_email='dmlb2000@gmail.com',
-    packages=find_packages(),
+    packages=find_packages(include=['pacifica.*']),
     namespace_packages=['pacifica'],
     install_requires=[str(ir.req) for ir in INSTALL_REQS],
     entry_points={

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Tests module containing all the testing of all the things."""

--- a/tests/project_jsonschema.json
+++ b/tests/project_jsonschema.json
@@ -14,9 +14,6 @@
         "closed_date": {
           "const": null
         },
-        "created_date": {
-          "const": "2019-07-22T16:11:27"
-        },
         "display_name": {
           "const": "Pacifica D\u00e9velopment (active no close)"
         },

--- a/tests/project_jsonschema.json
+++ b/tests/project_jsonschema.json
@@ -1,0 +1,86 @@
+{
+  "properties": {
+    "_source": {
+      "properties": {
+        "abstract": {
+          "const": "This is a currently active project with a set end date but no clos\u00e9d date"
+        },
+        "actual_end_date": {
+          "const": "2017-09-29"
+        },
+        "actual_start_date": {
+          "const": "2013-10-01"
+        },
+        "closed_date": {
+          "const": null
+        },
+        "created_date": {
+          "const": "2019-07-22T16:11:27"
+        },
+        "display_name": {
+          "const": "Pacifica D\u00e9velopment (active no close)"
+        },
+        "keyword": {
+          "const": "Pacifica D\u00e9velopment (active no close)"
+        },
+        "obj_id": {
+          "const": "projects_1234a"
+        },
+        "release": {
+          "const": "true"
+        },
+        "title": {
+          "const": "Pacifica D\u00e9velopment (active no close)"
+        },
+        "transaction_ids": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "projects"
+        },
+        "updated_date": {
+          "const": "2019-07-22T16:11:27"
+        },
+        "users": {
+          "properties": {
+            "t\u00e9st_rel_1": {
+              "items": {
+                "properties": {
+                  "created_date": {
+                    "const": "2019-07-22T16:11:27"
+                  },
+                  "display_name": {
+                    "const": "Brown\u00e9 Jr, David\u00e9 "
+                  },
+                  "keyword": {
+                    "const": "Brown\u00e9 Jr, David\u00e9 "
+                  },
+                  "obj_id": {
+                    "const": "users_10"
+                  },
+                  "release": {
+                    "const": "true"
+                  },
+                  "type": {
+                    "const": "users"
+                  },
+                  "updated_date": {
+                    "const": "2019-07-22T16:11:27"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/tests/project_jsonschema.json
+++ b/tests/project_jsonschema.json
@@ -38,17 +38,11 @@
         "type": {
           "const": "projects"
         },
-        "updated_date": {
-          "const": "2019-07-22T16:11:27"
-        },
         "users": {
           "properties": {
             "t\u00e9st_rel_1": {
               "items": {
                 "properties": {
-                  "created_date": {
-                    "const": "2019-07-22T16:11:27"
-                  },
                   "display_name": {
                     "const": "Brown\u00e9 Jr, David\u00e9 "
                   },
@@ -63,9 +57,6 @@
                   },
                   "type": {
                     "const": "users"
-                  },
-                  "updated_date": {
-                    "const": "2019-07-22T16:11:27"
                   }
                 },
                 "type": "object"

--- a/tests/transaction_jsonschema.json
+++ b/tests/transaction_jsonschema.json
@@ -1,0 +1,216 @@
+{
+  "properties": {
+    "_source": {
+      "properties": {
+        "access_url": {
+          "const": "https://dx.doi.org/10.25584/data.2018-03.127/123456"
+        },
+        "created_date": {
+          "const": "2017-07-15T00:00:00"
+        },
+        "has_doi": {
+          "const": "true"
+        },
+        "institutions": {
+          "items": {
+            "properties": {
+              "display_name": {
+                "const": "University of Washington\u00e9"
+              },
+              "keyword": {
+                "const": "University of Washington\u00e9"
+              },
+              "obj_id": {
+                "const": "institutions_47"
+              },
+              "type": {
+                "const": "institutions"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "instrument_groups": {
+          "items": {
+            "properties": {
+              "display_name": {
+                "const": "nmr_instrum\u00e9nts"
+              },
+              "keyword": {
+                "const": "nmr_instrum\u00e9nts"
+              },
+              "obj_id": {
+                "const": "groups_1001"
+              },
+              "type": {
+                "const": "groups"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "instruments": {
+          "items": {
+            "properties": {
+              "display_name": {
+                "const": "NMR PROBES: Nittany Liquid Prob\u00e9s"
+              },
+              "key_value_pairs": {
+                "properties": {
+                  "key_value_hash": {
+                    "properties": {
+                      "temp_f": {
+                        "const": "19"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "key_value_objs": {
+                    "items": {
+                      "properties": {
+                        "key": {
+                          "const": "temp_f"
+                        },
+                        "value": {
+                          "const": "19"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "keyword": {
+                "const": "NMR PROBES: Nittany Liquid Prob\u00e9s"
+              },
+              "long_name": {
+                "const": "NMR PROBES: Nittany Liquid Prob\u00e9s"
+              },
+              "obj_id": {
+                "const": "instruments_54"
+              },
+              "type": {
+                "const": "instruments"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "key_value_pairs": {
+          "properties": {
+            "key_value_hash": {
+              "properties": {
+                "temp_f": {
+                  "const": "27"
+                }
+              },
+              "type": "object"
+            },
+            "key_value_objs": {
+              "items": {
+                "properties": {
+                  "key": {
+                    "const": "temp_f"
+                  },
+                  "value": {
+                    "const": "27"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "obj_id": {
+          "const": "transactions_67"
+        },
+        "projects": {
+          "items": {
+            "properties": {
+              "abstract": {
+                "const": "This is a currently active project with a set end date but no clos\u00e9d date"
+              },
+              "display_name": {
+                "const": "Pacifica D\u00e9velopment (active no close)"
+              },
+              "keyword": {
+                "const": "Pacifica D\u00e9velopment (active no close)"
+              },
+              "long_name": {
+                "const": ""
+              },
+              "obj_id": {
+                "const": "projects_1234a"
+              },
+              "title": {
+                "const": "Pacifica D\u00e9velopment (active no close)"
+              },
+              "type": {
+                "const": "projects"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "release": {
+          "const": "true"
+        },
+        "science_themes": {
+          "items": {
+            "properties": {
+              "display_name": {
+                "const": "g\u00e9neral"
+              },
+              "obj_id": {
+                "const": "science_themes_g\u00e9neral"
+              },
+              "type": {
+                "const": "science_themes"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "transactions"
+        },
+        "users": {
+          "properties": {
+            "submitter": {
+              "items": {
+                "properties": {
+                  "display_name": {
+                    "const": "Brown\u00e9 Jr, David\u00e9 "
+                  },
+                  "keyword": {
+                    "const": "Brown\u00e9 Jr, David\u00e9 "
+                  },
+                  "obj_id": {
+                    "const": "users_10"
+                  },
+                  "type": {
+                    "const": "users"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
### Description

This adds some jsonschema validation testing of the documents we
create so additions to the model won't get lost over time.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
