### PR TITLE
Add command line options for dates and objects

### DIFF
--- a/pacifica/elasticsearch/__main__.py
+++ b/pacifica/elasticsearch/__main__.py
@@ -6,10 +6,12 @@ import logging
 from sys import argv as sys_argv
 from argparse import ArgumentParser
 from datetime import timedelta
+from .celery import SYNC_OBJECTS
 from .search_sync import search_sync
 
 logging.basicConfig()
 LOGGER = logging.getLogger('peewee')
+DEFAULT_CMP_DATES = ['created', 'updated']
 
 
 def objstr_to_timedelta(obj_str):
@@ -26,12 +28,36 @@ def exclude_options(obj_str):
     return (obj_cls, obj_attr, value)
 
 
+def object_options(obj_str):
+    """Convert an object and validate type."""
+    if obj_str not in SYNC_OBJECTS:
+        raise ValueError('{} is not a valid search sync object'.format(obj_str))
+    return obj_str
+
+
+def cmp_date_options(date_str):
+    """Validate the date string is something we can compare against."""
+    if date_str not in DEFAULT_CMP_DATES:
+        raise ValueError('{} is not in {}'.format(date_str, DEFAULT_CMP_DATES))
+    return date_str
+
+
 def searchsync_options(searchsync_parser):
     """Add the searchsync command line options."""
     searchsync_parser.add_argument(
         '--exclude', dest='exclude',
         help='object and attr to exclude (i.e. --exclude="projects._id=1234").',
         nargs='*', default=set(), type=exclude_options
+    )
+    searchsync_parser.add_argument(
+        '--object', dest='objects',
+        help='object to parse (i.e. --object="projects").',
+        nargs='*', default=set(SYNC_OBJECTS), type=object_options
+    )
+    searchsync_parser.add_argument(
+        '--compare-date', dest='compare_dates',
+        help='date to compare objects to (i.e. --compare-date="created").',
+        nargs='*', default=set(DEFAULT_CMP_DATES), type=cmp_date_options
     )
     searchsync_parser.add_argument(
         '--objects-per-page', default=40000,

--- a/tests/elasticsearch_test.py
+++ b/tests/elasticsearch_test.py
@@ -7,11 +7,20 @@ from time import sleep
 import json
 import jsonschema
 import requests
-from pacifica.elasticsearch.__main__ import main
+from pacifica.elasticsearch.__main__ import main, object_options, cmp_date_options
 
 
 class TestElasticsearch(TestCase):
     """Test the example class."""
+
+    def test_main_errors(self):
+        """Test some of the command line failure conditions."""
+        with self.assertRaises(ValueError, msg="blarg is not a valid object to sync"):
+            object_options('blarg')
+        with self.assertRaises(ValueError, msg='blarg is not a valid date to compare objects to'):
+            cmp_date_options('blarg')
+        self.assertEqual(object_options('users'), 'users')
+        self.assertEqual(cmp_date_options('created'), 'created')
 
     def test_main(self):
         """Test the add method in example class."""

--- a/tests/elasticsearch_test.py
+++ b/tests/elasticsearch_test.py
@@ -15,7 +15,7 @@ class TestElasticsearch(TestCase):
 
     def test_main_errors(self):
         """Test some of the command line failure conditions."""
-        with self.assertRaises(ValueError, msg="blarg is not a valid object to sync"):
+        with self.assertRaises(ValueError, msg='blarg is not a valid object to sync'):
             object_options('blarg')
         with self.assertRaises(ValueError, msg='blarg is not a valid date to compare objects to'):
             cmp_date_options('blarg')


### PR DESCRIPTION
### Description

This adds command line options to specify the dates to compare
objects to and the object list to sync.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
