### PR TITLE
The progress bar should reference the command line

### DIFF
--- a/pacifica/elasticsearch/celery.py
+++ b/pacifica/elasticsearch/celery.py
@@ -37,7 +37,7 @@ class CeleryQueue(object):
             self.by_obj_type[job_dict['object']] = []
         self.by_obj_type[job_dict['object']].append((job_dict, result))
 
-    def progress(self):
+    def progress(self, args):
         """
         Display progress bars on all items working.
 
@@ -47,8 +47,9 @@ class CeleryQueue(object):
         waiting for it to complete.
         """
         success = True
-        for object_index in trange(len(SYNC_OBJECTS), desc='Total Completed'):
-            object_name = SYNC_OBJECTS[object_index]
+        obj_list = list(args.objects)
+        for object_index in trange(len(obj_list), desc='Total Completed'):
+            object_name = obj_list[object_index]
             job_list = self.by_obj_type[object_name]
             for job_index in trange(len(job_list), desc='Total {} Completed'.format(object_name)):
                 _job_dict, result = self.by_obj_type[object_name][job_index]

--- a/pacifica/elasticsearch/search_sync.py
+++ b/pacifica/elasticsearch/search_sync.py
@@ -271,7 +271,7 @@ def search_sync(args):
         work_threads = create_worker_threads(args.threads, work_queue)
     generate_work(args, work_queue)
     if args.celery:
-        return work_queue.progress()
+        return work_queue.progress(args)
     for _i in range(args.threads):
         work_queue.put(False)
     for wthread in work_threads:

--- a/tests/elasticsearch_test.py
+++ b/tests/elasticsearch_test.py
@@ -48,6 +48,19 @@ class TestElasticsearch(TestCase):
         resp = requests.get('http://localhost:9200/pacifica_search/doc/transactions_67')
         self.assertEqual(resp.status_code, 200)
 
+    def test_main_celery_single_obj(self):
+        """Test the add method in example class."""
+        main('--objects-per-page', '4', '--celery', '--object=projects',
+             '--exclude', 'keys.key=temp_f', '--time-ago', '3650 days after')
+        sleep(3)
+        resp = requests.post('http://localhost:9200/pacifica_search/_flush/synced')
+        self.assertEqual(resp.status_code, 200)
+        resp = requests.get('http://localhost:9200/pacifica_search/_stats')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['indices']['pacifica_search']['primaries']['docs']['count'], 44)
+        resp = requests.get('http://localhost:9200/pacifica_search/doc/transactions_67')
+        self.assertEqual(resp.status_code, 200)
+
     def test_document_formats(self):
         """Verify a project document is of a specific format."""
         self.test_main()


### PR DESCRIPTION
### Description

The progress bar should reference the command line options for
parsing the objects and what tasks are done where.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

Fix #7 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
