### PR TITLE
Fix #11 Add ES Mapping JSON Document

### DIFF
--- a/pacifica/elasticsearch/mapping.json
+++ b/pacifica/elasticsearch/mapping.json
@@ -1,0 +1,121 @@
+{
+  "properties": {
+    "created_date": {
+      "type": "date"
+    },
+    "description": {
+      "type": "keyword"
+    },
+    "files": {
+      "properties": {
+        "created_date": {
+          "type": "date"
+        },
+        "keyword": {
+          "type": "keyword"
+        }
+      }
+    },
+    "groups": {
+      "properties": {
+        "keyword": {
+          "type": "keyword"
+        }
+      }
+    },
+    "has_doi": {
+      "fielddata": true,
+      "type": "text"
+    },
+    "institutions": {
+      "properties": {
+        "keyword": {
+          "type": "keyword"
+        }
+      }
+    },
+    "instruments": {
+      "properties": {
+        "keyword": {
+          "type": "keyword"
+        }
+      }
+    },
+    "key": {
+      "type": "keyword"
+    },
+    "key_value_pairs": {
+      "properties": {
+        "key": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword"
+        }
+      }
+    },
+    "keyword": {
+      "type": "keyword"
+    },
+    "projects": {
+      "properties": {
+        "actual_end_date": {
+          "type": "date"
+        },
+        "actual_start_date": {
+          "type": "date"
+        },
+        "closed_date": {
+          "type": "date"
+        },
+        "keyword": {
+          "type": "keyword"
+        }
+      }
+    },
+    "release": {
+      "type": "keyword"
+    },
+    "science_themes": {
+      "properties": {
+        "keyword": {
+          "type": "keyword"
+        }
+      }
+    },
+    "transaction_ids": {
+      "fielddata": true,
+      "type": "text"
+    },
+    "type": {
+      "type": "keyword"
+    },
+    "updated_date": {
+      "type": "date"
+    },
+    "users": {
+      "properties": {
+        "authorized_releaser": {
+          "properties": {
+            "keyword": {
+              "type": "keyword"
+            }
+          }
+        },
+        "keyword": {
+          "type": "keyword"
+        },
+        "submitter": {
+          "properties": {
+            "keyword": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    },
+    "value": {
+      "type": "keyword"
+    }
+  }
+}

--- a/pacifica/elasticsearch/search_sync.py
+++ b/pacifica/elasticsearch/search_sync.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 """Sync the database to elasticsearch index for use by Searching tools."""
 from __future__ import print_function, absolute_import
-from json import dumps
+import os
+from json import dumps, loads
 from time import sleep
 from threading import Thread
 try:
@@ -37,121 +38,7 @@ def es_client():
         [get_config().get('elasticsearch', 'url')],
         **es_kwargs
     )
-    mapping_params = {
-        'properties': {
-            'key': {'type': 'keyword'},
-            'value': {'type': 'keyword'},
-            'key_value_pairs': {
-                'properties': {
-                    'key': {'type': 'keyword'},
-                    'value': {'type': 'keyword'}
-                }
-            },
-            'release': {
-                'type': 'keyword'
-            },
-            'updated_date': {
-                'type': 'date'
-            },
-            'created_date': {
-                'type': 'date'
-            },
-            'transaction_ids': {
-                'type':     'text',
-                'fielddata': True
-            },
-            'has_doi': {
-                'type':      'text',
-                'fielddata': True
-            },
-            'description': {
-                'type': 'keyword'
-            },
-            'type': {
-                'type': 'keyword'
-            },
-            'keyword': {
-                'type': 'keyword'
-            },
-            'users': {
-                'properties': {
-                    'keyword': {
-                        'type': 'keyword'
-                    },
-                    'submitter': {
-                        'properties': {
-                            'keyword': {
-                                'type': 'keyword'
-                            }
-                        }
-                    },
-                    'authorized_releaser': {
-                        'properties': {
-                            'keyword': {
-                                'type': 'keyword'
-                            }
-                        }
-                    }
-                }
-            },
-            'instruments': {
-                'properties': {
-                    'keyword': {
-                        'type': 'keyword'
-                    }
-                }
-            },
-            'projects': {
-                'properties': {
-                    'keyword': {
-                        'type': 'keyword'
-                    },
-                    'closed_date': {
-                        'type': 'date'
-                    },
-                    'actual_start_date': {
-                        'type': 'date'
-                    },
-                    'actual_end_date': {
-                        'type': 'date'
-                    }
-                }
-            },
-            'institutions': {
-                'properties': {
-                    'keyword': {
-                        'type': 'keyword'
-                    },
-
-                }
-            },
-            'science_themes': {
-                'properties': {
-                    'keyword': {
-                        'type': 'keyword'
-                    },
-
-                }
-            },
-            'groups': {
-                'properties': {
-                    'keyword': {
-                        'type': 'keyword'
-                    },
-                }
-            },
-            'files': {
-                'properties': {
-                    'keyword': {
-                        'type': 'keyword'
-                    },
-                    'created_date': {
-                        'type': 'date'
-                    }
-                }
-            }
-        }
-    }
+    mapping_params = loads(open(os.path.join(os.path.dirname(__file__), 'mapping.json')).read())
     # pylint: disable=unexpected-keyword-arg
     esclient.indices.create(index=ELASTIC_INDEX, ignore=400)
     esclient.indices.put_mapping(

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
     packages=find_packages(include=['pacifica.*']),
     namespace_packages=['pacifica'],
     install_requires=[str(ir.req) for ir in INSTALL_REQS],
+    include_package_data=True,
+    package_data={'': ['*.json']},
     entry_points={
         'console_scripts': [
             'pacifica-elasticsearch=pacifica.elasticsearch.__main__:main',


### PR DESCRIPTION
### Description

This pulls the elasticsearch mapping document out of an embedded
python variable into a json document so we can manage and lint
them separately.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved
Fix #11 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
