### PR TITLE
Fix #15 - Project-centric data model requested

### DIFF
--- a/tests/issue_15_projects.json
+++ b/tests/issue_15_projects.json
@@ -1,0 +1,174 @@
+{
+  "aggs": {
+    "project": {
+      "aggs": {
+        "obj_id.keyword": {
+          "terms": {
+            "field": "obj_id.keyword",
+            "size": 10
+          }
+        },
+        "obj_id.keyword_count": {
+          "cardinality": {
+            "field": "obj_id.keyword"
+          }
+        }
+      }
+    },
+    "transaction_count": {
+      "aggs": {
+        "transaction_count": {
+          "range": {
+            "field": "transaction_count",
+            "ranges": [
+              {
+                "key": "All"
+              },
+              {
+                "key": "Up to 50",
+                "from": 1,
+                "to": 51
+              },
+              {
+                "key": "51 to 400",
+                "from": 51,
+                "to": 401
+              },
+              {
+                "key": "401 to 1000",
+                "from": 401,
+                "to": 1001
+              },
+              {
+                "key": "More than 1000",
+                "from": 1001
+              }
+            ]
+          }
+        }
+      }
+    },
+    "principal_investigator": {
+      "aggs": {
+        "users.principle_investigator.keyword": {
+          "terms": {
+            "field": "users.principle_investigator.keyword",
+            "size": 10
+          }
+        },
+        "users.principle_investigator.keyword_count": {
+          "cardinality": {
+            "field": "users.principle_investigator.keyword"
+          }
+        }
+      }
+    },
+    "co_principal_investigator": {
+      "aggs": {
+        "users.co_principle_investigator.keyword": {
+          "terms": {
+            "field": "users.co_principle_investigator.keyword",
+            "size": 10
+          }
+        },
+        "users.co_principle_investigator.keyword_count": {
+          "cardinality": {
+            "field": "users.co_principle_investigator.keyword"
+          }
+        }
+      }
+    },
+    "member_of": {
+      "aggs": {
+        "users.member_of.keyword": {
+          "terms": {
+            "field": "users.member_of.keyword",
+            "size": 10
+          }
+        },
+        "users.member_of.keyword_count": {
+          "cardinality": {
+            "field": "users.member_of.keyword"
+          }
+        }
+      }
+    },
+    "science_theme": {
+      "aggs": {
+        "science_themes.keyword": {
+          "terms": {
+            "field": "science_themes.keyword",
+            "size": 10
+          }
+        },
+        "science_themes.keyword_count": {
+          "cardinality": {
+            "field": "science_themes.keyword"
+          }
+        }
+      }
+    },
+    "institution": {
+      "aggs": {
+        "institutions.keyword": {
+          "terms": {
+            "field": "institutions.keyword",
+            "size": 10
+          }
+        },
+        "institutions.keyword_count": {
+          "cardinality": {
+            "field": "institutions.keyword"
+          }
+        }
+      }
+    },
+    "instruments": {
+      "aggs": {
+        "instruments.keyword": {
+          "terms": {
+            "field": "instruments.keyword",
+            "size": 10
+          }
+        },
+        "instruments.keyword_count": {
+          "cardinality": {
+            "field": "instruments.keyword"
+          }
+        }
+      }
+    },
+    "groups": {
+      "aggs": {
+        "groups.keyword": {
+          "terms": {
+            "field": "groups.keyword",
+            "size": 10
+          }
+        },
+        "groups.keyword_count": {
+          "cardinality": {
+            "field": "groups.keyword"
+          }
+        }
+      }
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "term": {
+            "type": "projects"
+          }
+        },
+        {
+          "script": {
+            "script": "doc['transaction_ids'].length > 0"
+          }
+        }
+      ]
+    }
+  },
+  "size": 15
+}

--- a/tests/issue_15_projects.json
+++ b/tests/issue_15_projects.json
@@ -1,6 +1,9 @@
 {
   "aggs": {
-    "project": {
+    "project3": {
+      "filter": {
+        "match_all": {}
+      },
       "aggs": {
         "obj_id.keyword": {
           "terms": {
@@ -15,7 +18,10 @@
         }
       }
     },
-    "transaction_count": {
+    "transaction_count5": {
+      "filter": {
+        "match_all": {}
+      },
       "aggs": {
         "transaction_count": {
           "range": {
@@ -48,7 +54,10 @@
         }
       }
     },
-    "principal_investigator": {
+    "principal_investigator8": {
+      "filter": {
+        "match_all": {}
+      },
       "aggs": {
         "users.principle_investigator.keyword": {
           "terms": {
@@ -63,7 +72,10 @@
         }
       }
     },
-    "co_principal_investigator": {
+    "co_principal_investigator9": {
+      "filter": {
+        "match_all": {}
+      },
       "aggs": {
         "users.co_principle_investigator.keyword": {
           "terms": {
@@ -78,7 +90,10 @@
         }
       }
     },
-    "member_of": {
+    "member_of10": {
+      "filter": {
+        "match_all": {}
+      },
       "aggs": {
         "users.member_of.keyword": {
           "terms": {
@@ -93,7 +108,10 @@
         }
       }
     },
-    "science_theme": {
+    "science_theme11": {
+      "filter": {
+        "match_all": {}
+      },
       "aggs": {
         "science_themes.keyword": {
           "terms": {
@@ -108,7 +126,10 @@
         }
       }
     },
-    "institution": {
+    "institution12": {
+      "filter": {
+        "match_all": {}
+      },
       "aggs": {
         "institutions.keyword": {
           "terms": {
@@ -123,7 +144,10 @@
         }
       }
     },
-    "instruments": {
+    "instruments13": {
+      "filter": {
+        "match_all": {}
+      },
       "aggs": {
         "instruments.keyword": {
           "terms": {
@@ -138,7 +162,10 @@
         }
       }
     },
-    "groups": {
+    "groups14": {
+      "filter": {
+        "match_all": {}
+      },
       "aggs": {
         "groups.keyword": {
           "terms": {

--- a/tests/issue_15_transactions.json
+++ b/tests/issue_15_transactions.json
@@ -1,6 +1,6 @@
 {
   "aggs": {
-    "release_data": {
+    "release_data3": {
       "filter": {
         "match_all": {}
       },
@@ -18,7 +18,7 @@
         }
       }
     },
-    "doi": {
+    "doi4": {
       "filter": {
         "match_all": {}
       },
@@ -36,7 +36,7 @@
         }
       }
     },
-    "instruments": {
+    "instruments6": {
       "filter": {
         "match_all": {}
       },
@@ -54,7 +54,7 @@
         }
       }
     },
-    "groups": {
+    "groups7": {
       "filter": {
         "match_all": {}
       },
@@ -72,7 +72,7 @@
         }
       }
     },
-    "Tag": {
+    "Tag8": {
       "filter": {
         "match_all": {}
       },
@@ -90,7 +90,7 @@
         }
       }
     },
-    "omics.dms.experiment_name": {
+    "omics.dms.experiment_name9": {
       "filter": {
         "match_all": {}
       },
@@ -107,6 +107,60 @@
           }
         }
       }
+    },
+    "omics.dms.dataset_name10": {
+      "filter": {
+        "match_all": {}
+      },
+      "aggs": {
+        "key_value_pairs.key_value_hash.omics.dms.dataset_name.keyword": {
+          "terms": {
+            "field": "key_value_pairs.key_value_hash.omics.dms.dataset_name.keyword",
+            "size": 10
+          }
+        },
+        "key_value_pairs.key_value_hash.omics.dms.dataset_name.keyword_count": {
+          "cardinality": {
+            "field": "key_value_pairs.key_value_hash.omics.dms.dataset_name.keyword"
+          }
+        }
+      }
+    },
+    "user_of_record11": {
+      "filter": {
+        "match_all": {}
+      },
+      "aggs": {
+        "key_value_pairs.key_value_hash.user_of_record.keyword": {
+          "terms": {
+            "field": "key_value_pairs.key_value_hash.user_of_record.keyword",
+            "size": 10
+          }
+        },
+        "key_value_pairs.key_value_hash.user_of_record.keyword_count": {
+          "cardinality": {
+            "field": "key_value_pairs.key_value_hash.user_of_record.keyword"
+          }
+        }
+      }
+    },
+    "proxymod.version12": {
+      "filter": {
+        "match_all": {}
+      },
+      "aggs": {
+        "key_value_pairs.key_value_hash.proxymod.version.keyword": {
+          "terms": {
+            "field": "key_value_pairs.key_value_hash.proxymod.version.keyword",
+            "size": 10
+          }
+        },
+        "key_value_pairs.key_value_hash.proxymod.version.keyword_count": {
+          "cardinality": {
+            "field": "key_value_pairs.key_value_hash.proxymod.version.keyword"
+          }
+        }
+      }
     }
   },
   "query": {
@@ -115,11 +169,6 @@
         {
           "term": {
             "type": "transactions"
-          }
-        },
-        {
-          "term": {
-            "_index": "pacifica_search_dmlb2000"
           }
         },
         {

--- a/tests/issue_15_transactions.json
+++ b/tests/issue_15_transactions.json
@@ -1,0 +1,134 @@
+{
+  "aggs": {
+    "release_data": {
+      "filter": {
+        "match_all": {}
+      },
+      "aggs": {
+        "release": {
+          "terms": {
+            "field": "release",
+            "size": 50
+          }
+        },
+        "release_count": {
+          "cardinality": {
+            "field": "release"
+          }
+        }
+      }
+    },
+    "doi": {
+      "filter": {
+        "match_all": {}
+      },
+      "aggs": {
+        "has_doi": {
+          "terms": {
+            "field": "has_doi",
+            "size": 50
+          }
+        },
+        "has_doi_count": {
+          "cardinality": {
+            "field": "has_doi"
+          }
+        }
+      }
+    },
+    "instruments": {
+      "filter": {
+        "match_all": {}
+      },
+      "aggs": {
+        "instruments.keyword": {
+          "terms": {
+            "field": "instruments.keyword",
+            "size": 10
+          }
+        },
+        "instruments.keyword_count": {
+          "cardinality": {
+            "field": "instruments.keyword"
+          }
+        }
+      }
+    },
+    "groups": {
+      "filter": {
+        "match_all": {}
+      },
+      "aggs": {
+        "groups.keyword": {
+          "terms": {
+            "field": "groups.keyword",
+            "size": 10
+          }
+        },
+        "groups.keyword_count": {
+          "cardinality": {
+            "field": "groups.keyword"
+          }
+        }
+      }
+    },
+    "Tag": {
+      "filter": {
+        "match_all": {}
+      },
+      "aggs": {
+        "key_value_pairs.key_value_hash.Tag.keyword": {
+          "terms": {
+            "field": "key_value_pairs.key_value_hash.Tag.keyword",
+            "size": 10
+          }
+        },
+        "key_value_pairs.key_value_hash.Tag.keyword_count": {
+          "cardinality": {
+            "field": "key_value_pairs.key_value_hash.Tag.keyword"
+          }
+        }
+      }
+    },
+    "omics.dms.experiment_name": {
+      "filter": {
+        "match_all": {}
+      },
+      "aggs": {
+        "key_value_pairs.key_value_hash.omics.dms.experiment_name.keyword": {
+          "terms": {
+            "field": "key_value_pairs.key_value_hash.omics.dms.experiment_name.keyword",
+            "size": 10
+          }
+        },
+        "key_value_pairs.key_value_hash.omics.dms.experiment_name.keyword_count": {
+          "cardinality": {
+            "field": "key_value_pairs.key_value_hash.omics.dms.experiment_name.keyword"
+          }
+        }
+      }
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "term": {
+            "type": "transactions"
+          }
+        },
+        {
+          "term": {
+            "_index": "pacifica_search_dmlb2000"
+          }
+        },
+        {
+          "term": {
+            "projects.obj_id": "projects_50635"
+          }
+        }
+      ]
+    }
+  },
+  "size": 15
+}

--- a/tests/project_jsonschema.json
+++ b/tests/project_jsonschema.json
@@ -17,6 +17,96 @@
         "display_name": {
           "const": "Pacifica D\u00e9velopment (active no close)"
         },
+        "institutions": {
+          "items": {
+            "properties": {
+              "display_name": {
+                "const": "University of Washington\u00e9"
+              },
+              "keyword": {
+                "const": "University of Washington\u00e9"
+              },
+              "obj_id": {
+                "const": "institutions_47"
+              },
+              "type": {
+                "const": "institutions"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "instrument_groups": {
+          "items": {
+            "properties": {
+              "display_name": {
+                "const": "nmr_instrum\u00e9nts"
+              },
+              "keyword": {
+                "const": "nmr_instrum\u00e9nts"
+              },
+              "obj_id": {
+                "const": "groups_1001"
+              },
+              "type": {
+                "const": "groups"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "instruments": {
+          "items": {
+            "properties": {
+              "display_name": {
+                "const": "NMR PROBES: Nittany Liquid Prob\u00e9s"
+              },
+              "key_value_pairs": {
+                "properties": {
+                  "key_value_hash": {
+                    "properties": {
+                      "temp_f": {
+                        "const": "19"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "key_value_objs": {
+                    "items": {
+                      "properties": {
+                        "key": {
+                          "const": "temp_f"
+                        },
+                        "value": {
+                          "const": "19"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "keyword": {
+                "const": "NMR PROBES: Nittany Liquid Prob\u00e9s"
+              },
+              "long_name": {
+                "const": "NMR PROBES: Nittany Liquid Prob\u00e9s"
+              },
+              "obj_id": {
+                "const": "instruments_54"
+              },
+              "type": {
+                "const": "instruments"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
         "keyword": {
           "const": "Pacifica D\u00e9velopment (active no close)"
         },
@@ -25,6 +115,23 @@
         },
         "release": {
           "const": "true"
+        },
+        "science_themes": {
+          "items": {
+            "properties": {
+              "display_name": {
+                "const": "g\u00e9neral"
+              },
+              "obj_id": {
+                "const": "science_themes_g\u00e9neral"
+              },
+              "type": {
+                "const": "science_themes"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
         },
         "title": {
           "const": "Pacifica D\u00e9velopment (active no close)"

--- a/tests/project_jsonschema.json
+++ b/tests/project_jsonschema.json
@@ -122,6 +122,9 @@
               "display_name": {
                 "const": "g\u00e9neral"
               },
+              "keyword": {
+                "const": "g\u00e9neral"
+              },
               "obj_id": {
                 "const": "science_themes_g\u00e9neral"
               },

--- a/tests/transaction_jsonschema.json
+++ b/tests/transaction_jsonschema.json
@@ -11,26 +11,6 @@
         "has_doi": {
           "const": "true"
         },
-        "institutions": {
-          "items": {
-            "properties": {
-              "display_name": {
-                "const": "University of Washington\u00e9"
-              },
-              "keyword": {
-                "const": "University of Washington\u00e9"
-              },
-              "obj_id": {
-                "const": "institutions_47"
-              },
-              "type": {
-                "const": "institutions"
-              }
-            },
-            "type": "object"
-          },
-          "type": "array"
-        },
         "instrument_groups": {
           "items": {
             "properties": {
@@ -162,23 +142,6 @@
         },
         "release": {
           "const": "true"
-        },
-        "science_themes": {
-          "items": {
-            "properties": {
-              "display_name": {
-                "const": "g\u00e9neral"
-              },
-              "obj_id": {
-                "const": "science_themes_g\u00e9neral"
-              },
-              "type": {
-                "const": "science_themes"
-              }
-            },
-            "type": "object"
-          },
-          "type": "array"
         },
         "type": {
           "const": "transactions"


### PR DESCRIPTION
### Description

Updated Test schema to reflect the desired model layout. This is in an effort to link more data to the project itself and use the project as a sighting scope to then show a limited subset of transactions (datasets) that a user is interested in.

### Issues Resolved

Fixes #15 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
