### PR TITLE
Add Python 3.7 and 3.8 Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,15 @@ jobs:
     - stage: lint
       before_script: skip
       script: pre-commit run -a
+    - python: 3.7
+      before_script: skip
+      script: pre-commit run -a
+    - python: 3.8
+      before_script: skip
+      script: pre-commit run -a
     - stage: test
+    - python: 3.7
+    - python: 3.8
 
 install:
   - pip install -r requirements-dev.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,8 @@ environment:
   BACKEND_URL: redis://127.0.0.1:6379/0
   matrix:
     - PYTHON: C:\Python36-x64
+    - PYTHON: C:\Python37-x64
+    - PYTHON: C:\Python38-x64
 
 before_test:
 - ps: >


### PR DESCRIPTION
### Description

This adds Python 3.7 and 3.8 to Travis CI and Appveyor testing
pipelines.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
